### PR TITLE
iss27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,8 @@ frontend/build
 
 !frontend/.env
 
-*/*.DS_Store
+*.DS_Store
+*.idea
 
 frontend/.eslintcache
 

--- a/data_extractor/db/TN_tables/TN_case_parser.py
+++ b/data_extractor/db/TN_tables/TN_case_parser.py
@@ -1,0 +1,203 @@
+# Individual Cases Text Parser
+# From Tamil Nadu Bulletins
+
+
+from __future__ import annotations
+from typing import TypedDict, Dict, Optional
+
+
+import pathlib
+import argparse
+import os
+import re
+import json
+
+
+_path_this_dir = pathlib.Path(__file__).parent
+_path_to_examples = _path_this_dir.joinpath("./case_examples")
+
+
+def read_test_text(test_text: str) -> CaseInfo:
+    return CaseInfo.extract(test_text)
+
+
+def read_test_file(filename: str) -> CaseInfo:
+    return read_test_text(open(filename).read())
+
+
+def process_data(cls, data: Dict):
+    response = cls()
+
+    for key in cls.__annotations__:
+
+        custom_enforcer_function = getattr(eval(cls.__annotations__[key].__forward_arg__), "extract", None)
+        response[key] = None
+
+        if callable(custom_enforcer_function):
+            response[key] = custom_enforcer_function(data[key])
+
+        else:
+
+            if data[key]:
+                response[key] = eval("{}(\"{}\")".format(cls.__annotations__[key].__forward_arg__, data[key].strip()))
+
+    return response
+
+
+class TestInfo(TypedDict):
+    date: str
+    details: str
+
+
+    @classmethod
+    def process(cls, data: Dict) -> DeathInfo:
+        return process_data(cls, data)
+
+
+    @classmethod
+    def extract(cls, text: str) -> DeathInfo:
+
+        if not text:
+            return None
+
+        input_text = text.strip()
+        regex = r'\D*(having|outcome of)\s*(?P<details>((?!\s+on\s+).)+)(\s*on\s+(?P<date>((?!\.$|\.\s+).)+))*.*$'
+
+        template = re.compile(regex, re.IGNORECASE|re.DOTALL)
+        matches = re.match(template, input_text).groupdict()
+
+        return cls.process(data = matches)
+
+
+
+class SymptomInfo(TypedDict):
+    days: int
+    details: str
+
+    @classmethod
+    def process(cls, data: Dict) -> DeathInfo:
+        return process_data(cls, data)
+
+
+    @classmethod
+    def extract(cls, text: str) -> DeathInfo:
+
+        if not text:
+            return None
+
+        input_text = text.strip()
+        regex = r'(?P<details>((?!\s+for).)+)(\s*for\s+(?P<days>\d+)\s+days)*.*$'
+
+        template = re.compile(regex, re.IGNORECASE|re.DOTALL)
+        matches = re.match(template, input_text).groupdict()
+
+        return cls.process(data = matches)
+
+
+class AdmissionInfo(TypedDict):
+    symptoms: SymptomInfo
+    location: str
+    date: str
+    time: str
+
+    @classmethod
+    def process(cls, data: Dict) -> DeathInfo:
+        return process_data(cls, data)
+
+
+    @classmethod
+    def extract(cls, text: str) -> DeathInfo:
+
+        if not text:
+            return None
+
+        input_text = text.strip()
+        regex = r'.*admitted\s+on\s+(?P<date>((?!\s).)+)(\s*at\s+(?P<time>((?!in|with).)+)\s+)*(\s*(in a|in|at a)\s+(?P<location_1>((?!with).)+)\s+)*(\s*with complaints of\s+(?P<symptoms>((?!in a\s+|at\s+|$).)+)\s*)*(\s*(in a|in|at a)\s+(?P<location_2>((?!\s+and|$).)+)\s*)*.*$'
+
+        template = re.compile(regex, re.IGNORECASE|re.DOTALL)
+
+        matches = re.match(template, input_text).groupdict()
+        matches["location"] = matches["location_1"] or matches["location_2"]
+
+        return cls.process(data = matches)
+
+
+class DeathInfo(TypedDict):
+    cause: str
+    date: str
+    time: str
+
+    @classmethod
+    def process(cls, data: Dict) -> DeathInfo:
+        return process_data(cls, data)
+
+    @classmethod
+    def extract(cls, text: str) -> DeathInfo:
+
+        input_text = text.strip()
+        derived_dict = dict()
+        regex = r'.*died\s+on\s+(?P<date>((?!\s).)+)(\s+at\s+(?P<time>((?!due|$).)+)\s+)*(due\s+to(?P<cause>.+))*.*$'
+
+        template = re.compile(regex, re.IGNORECASE|re.DOTALL)
+        matches = re.match(template, input_text).groupdict()
+        derived_dict = {**derived_dict, **matches}
+
+        return cls.process(data = derived_dict)
+
+
+class CaseInfo(TypedDict):
+    case_id: int
+    age: int
+    gender: str
+    location: str
+    comorbidity: str
+    test: TestInfo
+    admission: AdmissionInfo
+    death: DeathInfo
+    raw_data: str
+
+    @classmethod
+    def process(cls, data: Dict) -> CaseInfo:
+        return process_data(cls, data)
+
+    @classmethod
+    def extract(cls, text: str) -> CaseInfo:
+
+        input_text = text.strip()
+        derived_dict = dict()
+
+        regex = r'\D*((?P<case_id>\d+)*\D*\n+)*(?P<raw_data>.*)$'
+        template = re.compile(regex, re.IGNORECASE|re.DOTALL)
+        matches = re.match(template, input_text).groupdict()
+
+        matches["raw_data"] = matches["raw_data"].replace('\n', ' ')
+
+        derived_dict = {**derived_dict, **matches}
+
+        regex = r'\D*(?P<age>\d+) year[s]* old (?P<gender>\D+) from (?P<location>((?!having|with|admitted).)*)(?P<test_info_1>having((?!with|admitted).)*)*(?P<comorbidity>with((?!admitted).)*)*(?P<admission>admitted((?!died|\.\s+|\.$).)*)*(?P<test_info_2>((?!died).)+)*(?P<death>died on.*)*\..*$'
+
+        template = re.compile(regex, re.IGNORECASE)
+        matches = re.match(template, derived_dict["raw_data"])
+        matches = matches.groupdict()
+
+        matches["test"] = matches["test_info_1"] or matches["test_info_2"]
+        derived_dict = {**derived_dict, **matches}
+
+        return cls.process(data = derived_dict)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Parser for Tamil Nadu case data.')
+    parser.add_argument('--file', type=str, help='File containing text.')
+
+    args = parser.parse_args()
+
+    if args.file: print(json.dumps(read_test_file(args.file), indent=4))
+    else:
+
+        list_of_test_files = [f.path for f in os.scandir(_path_to_examples) if f.path.endswith('.txt')]
+        for test_file in list_of_test_files:
+            print('Reading file', test_file)
+            print(json.dumps(read_test_file(test_file), indent=4))
+

--- a/data_extractor/db/TN_tables/case_examples/161.txt
+++ b/data_extractor/db/TN_tables/case_examples/161.txt
@@ -1,0 +1,4 @@
+Death case No.161:
+
+A 78 years old male from Chennai with Diabetes Mellitus / Systemic Hypertension / Coronary Artery Disease admitted on 28.05.2020 with complaints of fever, sore throat and breathing difficulty at a private hospital, Chennai and died on 29.05.2020 at 10.05 PM due to Pneumonia.
+

--- a/data_extractor/db/TN_tables/case_examples/162.txt
+++ b/data_extractor/db/TN_tables/case_examples/162.txt
@@ -1,0 +1,5 @@
+
+Death case No.162:
+
+A 74 years old male from Chennai with Diabetes Mellitus / Systemic Hypertension / Coronary Artery Disease-DVD-LVEF(42%) / Complete Heart Block-S/P-PPI (on 13.05.2020) admitted on 25.05.2020 with complaints of fever, vomiting, Generalized Weakness and Decreased Sensorium at a private hospital, Chennai and died on 30.05.2020 at 05.40 AM due to Respiratory Failure.
+

--- a/data_extractor/db/TN_tables/case_examples/163.txt
+++ b/data_extractor/db/TN_tables/case_examples/163.txt
@@ -1,0 +1,3 @@
+Death Case No.163:
+
+A 63 years old male from Chennai with Diabetes Mellitus admitted on 27.05.2020 with complaints of fever, Breathing Difficulty at a private hospital, Chennai and died on 30.05.2020 at 11.00 AM due to Respiratory Failure.

--- a/data_extractor/db/TN_tables/case_examples/164.txt
+++ b/data_extractor/db/TN_tables/case_examples/164.txt
@@ -1,0 +1,5 @@
+
+Death Case No.164:
+
+A 49 years old male from Namakkal with complaints of fever, cough and breathlessness admitted on 29.05.2020 at 10.20 PM at Government Medical College Hospital, Namakkal and died on 29.05.2020 at 10.36 PM due to Respiratory Failure / Pneumonia.
+

--- a/data_extractor/db/TN_tables/case_examples/165.txt
+++ b/data_extractor/db/TN_tables/case_examples/165.txt
@@ -1,0 +1,3 @@
+Death Case No.165:
+
+A 37 years old male from Kancheepuram with complaints of breathing difficulty admitted on 16.05.2020 at 8.00 PM at a Private Hospital, Chennai and died on 29.05.2020 at 10.40 AM due to Acute Respiratory Distress Syndrome.

--- a/data_extractor/db/TN_tables/case_examples/34922.txt
+++ b/data_extractor/db/TN_tables/case_examples/34922.txt
@@ -1,0 +1,4 @@
+A 56 years old Male from Chennai with DM/SHTN admitted on 27.08.2021
+at 08.45PM in Kilpauk Medical College Hospital, Chennai. Outcome of
+COVID test positive result on 29.08.2021. The patient died on 30.08.2021 at
+08.30AM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34923.txt
+++ b/data_extractor/db/TN_tables/case_examples/34923.txt
@@ -1,0 +1,5 @@
+Death Case No. 34923
+A 65 years old Male from Trichy admitted on 17.08.2021 in Mahathma
+Gandhi Memorial Government Hospital, Trichy. Outcome of COVID test
+positive result on 17.08.2021. The patient died on 30.08.2021 at 05.35AM
+due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34924.txt
+++ b/data_extractor/db/TN_tables/case_examples/34924.txt
@@ -1,0 +1,5 @@
+Death Case No. 34924
+A 52 years old Male from Nagapattinam with Type2DM admitted on
+30.08.2021 in Mahathma Gandhi Memorial Government Hospital, Trichy.
+Outcome of COVID test positive result on 29.08.2021. The patient died on
+30.08.2021 at 03.45PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34925.txt
+++ b/data_extractor/db/TN_tables/case_examples/34925.txt
@@ -1,0 +1,5 @@
+Death Case No. 34925
+A 60 years old Male from Trichy with Type2DM admitted on 12.08.2021 in
+Mahathma Gandhi Memorial Government Hospital, Trichy. Outcome of
+COVID test positive result on 25.08.2021. The patient died on 30.08.2021 at
+08.15PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34926.txt
+++ b/data_extractor/db/TN_tables/case_examples/34926.txt
@@ -1,0 +1,6 @@
+
+Death Case No. 34926
+A 72 years old Female from Pudukottai with Type2DM admitted on
+23.08.2021 at 04.25PM in Pudukkottai Medical College Hospital. Outcome
+of COVID test positive result on 22.08.2021. The patient died on 31.08.2021
+at 04.53AM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34927.txt
+++ b/data_extractor/db/TN_tables/case_examples/34927.txt
@@ -1,0 +1,6 @@
+
+Death Case No. 34927
+A 80 years old Male from Coimbatore with COPD admitted on 30.08.2021 at
+07.51AM in Coimbatore Medical College Hospital. Outcome of COVID test
+positive result on 30.08.2021. The patient died on 30.08.2021 at 01.00PM
+due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34928.txt
+++ b/data_extractor/db/TN_tables/case_examples/34928.txt
@@ -1,0 +1,5 @@
+Death Case No. 34928
+A 70 years old Male from Coimbatore with Type2DM/Old CVA admitted on
+23.08.2021 at 01.40PM in Coimbatore Medical College Hospital. Outcome of
+COVID test positive result on 21.08.2021. The patient died on 30.08.2021 at
+06.00PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34929.txt
+++ b/data_extractor/db/TN_tables/case_examples/34929.txt
@@ -1,0 +1,7 @@
+
+
+A 73 years old Male from Thiruvallur with Type2DM/CAD/SHTN admitted
+on 12.08.2021 at 01.55PM in Government Omandurar Medical College and
+Hospital, Chennai. Outcome of COVID test positive result on 11.08.2021.
+The patient died on 30.08.2021 at 11.00PM due to COVID-19 Pneumonia.
+

--- a/data_extractor/db/TN_tables/case_examples/34930.txt
+++ b/data_extractor/db/TN_tables/case_examples/34930.txt
@@ -1,0 +1,4 @@
+A 72 years old Male from Cuddalore admitted on 20.08.2021 at 09.30AM in
+Government Omandurar Medical College and Hospital, Chennai. Outcome of
+COVID test positive result on 18.08.2021. The patient died on 30.08.2021 at
+08.43PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34931.txt
+++ b/data_extractor/db/TN_tables/case_examples/34931.txt
@@ -1,0 +1,4 @@
+A 50 Years old Male from Cuddalore having COVID-19 RTPCR Positivity on
+14.08.2021 admitted on 13.08.2021 at 02.35 AM in GHQH, Perambalur
+with complaints of Fever for 2 days and Difficulty in Breathing for 1 day died
+on 01.09.2021 at 04.40 AM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34932.txt
+++ b/data_extractor/db/TN_tables/case_examples/34932.txt
@@ -1,0 +1,6 @@
+DEATH CASE NO. 34932
+A 80 Years old Male from Thanjavur having COVID-19 RTPCR Positivity on
+20.08.2021 with DM/HTN/CAD admitted on 20.08.2021 at 06.27 PM in a
+private hospital, Thanjavur with complaints of Fever for 3 days, Cough for 2
+days and Difficulty in Breathing died on 01.09.2021 at 01.30 AM due to
+COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34933.txt
+++ b/data_extractor/db/TN_tables/case_examples/34933.txt
@@ -1,0 +1,6 @@
+DEATH CASE NO. 34933
+A 48 Years old Male from Salem having COVID-19 RTPCR Positivity on
+25.08.2021 with Type2DM admitted on 24.08.2021 at 09.37 PM in a private
+hospital, Dindigul with complaints of Fever for 10 days, Cough for 6 days
+and Difficulty in Breathing for 3 days died on 01.09.2021 at 03.02 AM due
+to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34934.txt
+++ b/data_extractor/db/TN_tables/case_examples/34934.txt
@@ -1,0 +1,6 @@
+
+DEATH CASE NO. 34934
+A 70 Years old Male from Pudukottai having COVID-19 RTPCR Positivity on
+29.08.2021 admitted on 29.08.2021 at 12.00 PM in a private hospital,
+Thanjavur with complaints of Fever, Cough and Difficulty in Breathing for
+10 days died on 31.08.2021 at 07.30 PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34935.txt
+++ b/data_extractor/db/TN_tables/case_examples/34935.txt
@@ -1,0 +1,6 @@
+DEATH CASE NO. 34935
+A 70 Years old Female from Mayiladuthurai having COVID-19 RTPCR
+Positivity on 07.08.2021 admitted on 07.08.2021 at 06.31 PM in
+Government Periyar Hospital, Mayiladuthurai with complaints of Fever,
+Cough and Difficulty in Breathing for 8 days died on 31.08.2021 at 02.15
+PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34936.txt
+++ b/data_extractor/db/TN_tables/case_examples/34936.txt
@@ -1,0 +1,6 @@
+DEATH CASE NO. 34936
+A 70 Years old Male from Mayiladuthurai having COVID-19 RTPCR Positivity
+on 26.08.2021 with HTN/DM admitted on 26.08.2021 at 02.13 PM in
+Government Periyar Hospital, Mayiladuthurai with complaints of Fever,
+Cough and Difficulty in Breathing for 2 days died on 31.08.2021 at 03.45
+AM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34937.txt
+++ b/data_extractor/db/TN_tables/case_examples/34937.txt
@@ -1,0 +1,5 @@
+DEATH CASE NO. 34937
+A 70 Years old Male from Cuddalore having COVID-19 RTPCR Positivity on
+28.08.2021 admitted on 27.08.2021 at 01.18 PM in GHQH Cuddalore with
+complaints of Fever and Cough for 6 days, Difficulty in Breathing for 1 day
+died on 30.08.2021 at 08.50 PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34938.txt
+++ b/data_extractor/db/TN_tables/case_examples/34938.txt
@@ -1,0 +1,6 @@
+DEATH CASE NO. 34938
+A 85 Years old Female from Chennai having COVID-19 RTPCR Positivity on
+29.08.2021 with DM/HTN/CAD admitted on 29.08.2021 at 05.20 PM in
+Southern Railway Headquarters Hospital, Perambur, Chennai with
+complaints of Fever for 2 days and Difficulty in Breathing died on
+30.08.2021 at 06.15 PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34939.txt
+++ b/data_extractor/db/TN_tables/case_examples/34939.txt
@@ -1,0 +1,5 @@
+DEATH CASE NO. 34939
+A 48 Years old Male from Chengalpattu having COVID-19 RTPCR Positivity
+on 28.08.2021 with Type2DM/CKD admitted on 30.08.2021 in a private
+hospital, Chengalpattu with complaints of Difficulty in Breathing for 4 days
+died on 30.08.2021 at 10.20 PM due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34940.txt
+++ b/data_extractor/db/TN_tables/case_examples/34940.txt
@@ -1,0 +1,6 @@
+DEATH CASE NO. 34940
+A 77 Years old Male from Tiruppur having COVID-19 RTPCR Positivity on
+25.08.2021 with Type2DM/SHTN/Parkinson's Disease admitted on
+24.08.2021 at 04.00 PM in a private hospital, Tiruppur with complaints of
+Fever, Cough and Difficulty in Breathing died on 29.08.2021 at 12.05 PM
+due to COVID-19 Pneumonia.

--- a/data_extractor/db/TN_tables/case_examples/34941.txt
+++ b/data_extractor/db/TN_tables/case_examples/34941.txt
@@ -1,0 +1,4 @@
+A 79 Years old Male from Cuddalore having COVID-19 RTPCR Positivity on
+20.08.2021 with HTN/DM admitted on 21.08.2021 at 09.36 PM in a private
+hospital, Chennai with complaints of Cough for 7 days died on 28.08.2021
+at 02.25 PM due to COVID-19 Pneumonia.


### PR DESCRIPTION
#27 Case Info extractor for Tamil Nadu

@sachingrover211 import and run `CaseInfo.extract(text)` on the Tamil Nadu individual cases (should work for texts with or without the case id part in them); let me know if you hit errors. I have tested on the examples in the `case_examples` dir -- once we are ready to merge, we can remove these test cases.

```
{
    "case_id": null,
    "age": 79,
    "gender": "Male",
    "location": "Cuddalore",
    "comorbidity": "with HTN/DM",
    "test": {
        "date": "20.08.2021",
        "details": "COVID-19 RTPCR Positivity"
    },
    "admission": {
        "symptoms": {
            "days": 7,
            "details": "Cough"
        },
        "location": "private hospital, Chennai",
        "date": "21.08.2021",
        "time": "09.36 PM"
    },
    "death": {
        "cause": "COVID-19 Pneumonia",
        "date": "28.08.2021",
        "time": "02.25 PM"
    },
    "raw_data": "79 Years old Male from Cuddalore having COVID-19 RTPCR Positivity on 20.08.2021 with HTN/DM admitted on 21.08.2021 at 09.36 PM in a private hospital, Chennai with complaints of Cough for 7 days died on 28.08.2021 at 02.25 PM due to COVID-19 Pneumonia."
}

```